### PR TITLE
chore: update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
 # see https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
 
-*  @n1ckl0sk0rtge @Petzys
+*  @PQCA/cbomkit-maintainers


### PR DESCRIPTION
The current CODEOWNERS is invalid and does not match the ACLs.