### PR TITLE
Fix docker build FromAsCasing warning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM golang:1.24-alpine as builder
+FROM golang:1.24-alpine AS builder
 
 WORKDIR /app
 


### PR DESCRIPTION
Docker build throws a warning as below
```
WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 17)
```

https://docs.docker.com/reference/build-checks/from-as-casing/